### PR TITLE
[fix]修复SlidingTabLayout2底部导航条bug

### DIFF
--- a/FlycoTabLayout_Lib/src/main/java/com/flyco/tablayout/SlidingTabLayout2.java
+++ b/FlycoTabLayout_Lib/src/main/java/com/flyco/tablayout/SlidingTabLayout2.java
@@ -38,6 +38,8 @@ import java.util.List;
 public class SlidingTabLayout2 extends SlidingTabLayoutBase {
 
   private ViewPager2 mViewPager;
+  private boolean mViewPageScrolling = false;
+  
   /**
    * 用于监听viewpager2变化然后做出改变
    */
@@ -190,11 +192,25 @@ public class SlidingTabLayout2 extends SlidingTabLayoutBase {
 
     @Override
     public void onPageSelected(int position) {
+        if (!mViewPageScrolling) {
+                if (position != mCurrentTab) {
+                    mCurrentTab = position;
+                    mCurrentPositionOffset = 0;
+                    tabScaleTransformer.onPageScrolled(position, 0, 0);
+                    scrollToCurrentTab();
+                    invalidate();
+                }
+        }
       updateTabSelection(position);
     }
 
     @Override
     public void onPageScrollStateChanged(int state) {
+       if (state == 2) {
+                mViewPageScrolling = true;
+            } else {
+                mViewPageScrolling = false;
+            }
     }
   }
 


### PR DESCRIPTION
修复外部调用viewpage2的setCurrentItem()但不开启平滑滚动时，底部导航栏无法监听到onPageScrolled()事件，导致没有刷新的问题